### PR TITLE
Make current_desktop method work with Python 2 and 3

### DIFF
--- a/wmctrl.py
+++ b/wmctrl.py
@@ -42,6 +42,8 @@ class Window(BaseWindow):
 
 def current_desktop():
 	out = subprocess.check_output(['wmctrl', '-d'])
+	if type(out) is not str:  # Python3 comes back as bytes
+		out = out.decode()
 	for line in out.splitlines():
 		parts = line.split()
 		if parts[1] == "*":


### PR DESCRIPTION
If check_output returns something other than a string (comes back as bytes in python3), decode to a string. 

This should work in Python2 or Python3 (tested both).