### PR TITLE
Raise an ImportError if the wmctrl executable is not available

### DIFF
--- a/wmctrl.py
+++ b/wmctrl.py
@@ -2,6 +2,12 @@ import os
 import subprocess
 from collections import namedtuple
 import re
+import shutil
+
+# If wmctrl is not available anywhere on the PATH, then we should immediately fail to import this module
+# as any attempts by clients to use it later on will fail
+if not shutil.which('wmctrl'):
+    raise ImportError('Cannot import "wmctrl" python module, wmctrl executable was not found on the system PATH')
 
 #This code is heavily inspired by a wmctrl module by Antonio Cuni: bitbucket.org/antocuni/wmctrl
 # His module does a ton of stuff I don't care about though, so I've built mine from scratch.


### PR DESCRIPTION
edmbutton does check to see if a couple errors happen when determining whether or not to use wmctrl, like here:

https://github.com/slaclab/edmbutton/blob/44a8b9c60eb7a7b19d3260230c9433b512b11b1f/edmbutton/edm_button.py#L8-L11

But the issue is that wmctrl does not currently raise either of those on import even if no `wmctrl` executable is available. So the import succeeds, but it will then later raise a FileNotFound when trying to use it.

This PR just causes it to fail immediately, which will be detected by edm button and then the code you've already written to handle that case works just fine. And I think this approach to fail immediately is fine in general for any other use of this module too, since it can't do much without an instance of wmctrl to work with.

Put the new code in `wmctrl.py` instead of `__init__.py` just to keep it a simple module import rather than turning it into a package.